### PR TITLE
Chain of responsibility Pattern

### DIFF
--- a/_14chainofresponsbility/examples/LimitSupport.kt
+++ b/_14chainofresponsbility/examples/LimitSupport.kt
@@ -1,0 +1,9 @@
+class LimitSupport(
+  name: String,
+  // 이 번호 미만이면 해결할 수 있다
+  private val limit: Int
+) : Support(name) {
+  override fun resolve(trouble: Trouble): Boolean {
+    return trouble.number < limit
+  }
+}

--- a/_14chainofresponsbility/examples/Main.kt
+++ b/_14chainofresponsbility/examples/Main.kt
@@ -1,0 +1,21 @@
+object Main {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val alice: Support = NoSupport("Alice")
+    val bob: Support = LimitSupport("Bob", 100)
+    val charlie: Support = SpecialSupport("Charlie", 429)
+    val diana: Support = LimitSupport("Diana", 200)
+    val elmo: Support = OddSupport("Elmo")
+    val fred: Support = LimitSupport("Fred", 300)
+
+    // 책임을 넘길 체인을 만든다. 원래는 클라이언트에서 만들면 안된다. 세부사항(구현체)이 드러나기 때문이다. 나라면 팩토리를 사용할 것이다. 그러나 여기서는 간단하게 구현하기 위해 메인에서 만든다.
+    alice.setNext(bob).setNext(charlie).setNext(diana).setNext(elmo).setNext(fred)
+
+    // 다양한 id 를 부여한 트러블 발생
+    var i = 0
+    while (i < 500) {
+      alice.support(Trouble(i))
+      i += 33
+    }
+  }
+}

--- a/_14chainofresponsbility/examples/NoSupport.kt
+++ b/_14chainofresponsbility/examples/NoSupport.kt
@@ -1,0 +1,6 @@
+class NoSupport(name: String) : Support(name) {
+  override fun resolve(trouble: Trouble): Boolean {
+    // 자신은 아무것도 해결하지 않는다
+    return false
+  }
+}

--- a/_14chainofresponsbility/examples/OddSupport.kt
+++ b/_14chainofresponsbility/examples/OddSupport.kt
@@ -1,0 +1,5 @@
+class OddSupport(name: String) : Support(name) {
+  override fun resolve(trouble: Trouble): Boolean {
+    return trouble.number % 2 == 1
+  }
+}

--- a/_14chainofresponsbility/examples/SpecialSupport.kt
+++ b/_14chainofresponsbility/examples/SpecialSupport.kt
@@ -1,0 +1,9 @@
+class SpecialSupport(
+  // 이 번호만 해결할 수 있다.
+  name: String,
+  private val number: Int
+) : Support(name) {
+  override fun resolve(trouble: Trouble): Boolean {
+    return trouble.number == number
+  }
+}

--- a/_14chainofresponsbility/examples/Support.kt
+++ b/_14chainofresponsbility/examples/Support.kt
@@ -1,0 +1,38 @@
+abstract class Support(
+  // 이 트러블 해결자 이름
+  private val name: String
+) {
+  // 다음 번에 넘길 해결자
+  private var next: Support? = null
+
+  // 넘길 해결자를 설정한다
+  fun setNext(next: Support): Support {
+    this.next = next
+    return next
+  }
+
+  // 트러블 해결 절차를 결정한다
+  fun support(trouble: Trouble) {
+    if (resolve(trouble)) {
+      done(trouble)
+    } else if (next != null) {
+      next!!.support(trouble)
+    } else {
+      fail(trouble)
+    }
+  }
+
+  override fun toString(): String {
+    return "[$name]"
+  }
+
+  protected abstract fun resolve(trouble: Trouble): Boolean
+
+  private fun done(trouble: Trouble) {
+    println("$trouble is resolved by $this.")
+  }
+
+  private fun fail(trouble: Trouble) {
+    println("$trouble cannot be resolved.")
+  }
+}

--- a/_14chainofresponsbility/examples/Trouble.kt
+++ b/_14chainofresponsbility/examples/Trouble.kt
@@ -1,0 +1,8 @@
+class Trouble(
+  // 트러블 번호
+  val number: Int
+) {
+  override fun toString(): String {
+    return "[Trouble $number]"
+  }
+}

--- a/_14chainofresponsbility/questions/Question14-1.txt
+++ b/_14chainofresponsbility/questions/Question14-1.txt
@@ -1,0 +1,3 @@
+Q. GUI 앱은 Chain of Responsibility 패턴을 자주 사용합니다. GUI 앱상에는 버튼과 텍스트 상자, 체크 박스 등의 컴포넌트(위젯, 컨트롤 등이라고도 함)가 있습니다. 컴포넌트를 클릭했을 때에 발생하는 이벤트를 어떻게 떠넘길 수 있을까요? Chain of Responsibility 패턴의 'next(떠넘길 곳)는 어디에 등장하나요?
+
+A. 이벤트는 상위의 컴포넌트로 전파 (propagation) 됩니다

--- a/_14chainofresponsbility/questions/Question14-2.txt
+++ b/_14chainofresponsbility/questions/Question14-2.txt
@@ -1,0 +1,3 @@
+Q. 예제 프로그램의 Support 클래스(리스트 14-2)에서 support 메소드는 public이지만, resolve 메소드는 protected입니다. 클래스 설계자가 이렇게 구분한 의도는 무엇일까요?
+
+A. public 메서드인 support를 노출하여 이를 사용하도록 유도했습니다.

--- a/_14chainofresponsbility/questions/Question14-3.txt
+++ b/_14chainofresponsbility/questions/Question14-3.txt
@@ -1,0 +1,18 @@
+Q. 예제 프로그램의 support 메소드(리스트 14-2)를 재귀적으로 호출하는 대신 루프로 전개해 봅시다.
+
+A.
+```kotlin
+  fun support(trouble: Trouble) {
+    var obj: Support? = this
+    while (true) {
+      if (obj!!.resolve(trouble)) {
+        obj.done(trouble)
+        break
+      } else if (obj.next == null) {
+        obj.fail(trouble)
+        break
+      }
+      obj = obj.next
+    }
+  }
+```


### PR DESCRIPTION
Chain of responsibility Pattern
- 같은 인터페이스를 구현한 구현체의 리스트를 가지고 있는 객체가 한 구현체의 해결 여부에 따라 다음 구현체에게 실행을 맡기는 패턴 

Note
- 개인적으로는 컴포짓 패턴이랑 비슷하지만 컴포짓은 모든 구현체가 다 동작하지만 이 패턴은 여러 구현체 중 처리할 수 있는 하나만 동작하고 나머지는 동작하지 않는 구조로 보여.
- 14-2번 문제처럼 HTML 이벤트 전파와 같이 한번 처리되면 그 뒤로는 처리되지 않아야할 경우에 사용하면 좋을듯해. 이전에 주희가 필터 구현할 때에 컴포짓 사용했다고 말해줬는데 만일 필터의 요구사항이 한번 필터링되면 다음 필터는 거치지 않는다면 이 패턴이랑도 유사할듯? 내가 예시로 들었던 인스펙터는 모든 인스펙터 구현체를 다 돌고 그 결과를 리포트하는 리스트를 반환해서 최종적으로 슬랙으로 쏴줘서 결국 다 돌았어야 했어.